### PR TITLE
feat: using aesop to automate bounding of numeric values

### DIFF
--- a/SP1Foundations/Field.lean
+++ b/SP1Foundations/Field.lean
@@ -32,7 +32,12 @@ instance : Field BabyBear := ZMod.instField BabyBearPrime
 
 section const_vals
 
+lemma eq_one_iff_val_eq_one (x : BabyBear) : x = 1 ↔ x.val = 1 := by
+  rw [← Fin.val_one, Fin.val_inj]
+
 @[simp] lemma val_256 : ((256 : BabyBear) : ℕ) = 256 := rfl
+
+@[simp] lemma val_65536 : ((65536 : BabyBear) : ℕ) = 65536 := rfl
 
 end const_vals
 

--- a/SP1Foundations/Unsigned.lean
+++ b/SP1Foundations/Unsigned.lean
@@ -58,6 +58,14 @@ lemma U16_eq_zero_iff (x : U16) : x = 0 ↔ x.val = 0 := by
 lemma U16_eq_one_iff (x : U16) : x = 1 ↔ x.val = 1 := by
   refine ⟨congr_arg U16.val, fun h => U16.ext h⟩
 
+@[simp]
+lemma U16_eq_zero_iff' (x : U16) : x = U16.zero ↔ x.val = 0 := by
+  refine ⟨congr_arg U16.val, fun h => U16.ext h⟩
+
+@[simp]
+lemma U16_eq_one_iff' (x : U16) : x = U16.one ↔ x.val = 1 := by
+  refine ⟨congr_arg U16.val, fun h => U16.ext h⟩
+
 -- For converting BabyBear to U16, we can define a function that returns Option
 def BabyBear.toU16? (b : BabyBear) : Option U16 :=
   if h : b < base then some ⟨b, h⟩ else none
@@ -97,6 +105,14 @@ lemma U8_eq_zero_iff (x : U8) : x = 0 ↔ x.val = 0 := by
 
 @[simp]
 lemma U8_eq_one_iff (x : U8) : x = 1 ↔ x.val = 1 := by
+  refine ⟨congr_arg U8.val, fun h => U8.ext h⟩
+
+@[simp]
+lemma U8_eq_zero_iff' (x : U8) : x = U8.zero ↔ x.val = 0 := by
+  refine ⟨congr_arg U8.val, fun h => U8.ext h⟩
+
+@[simp]
+lemma U8_eq_one_iff' (x : U8) : x = U8.one ↔ x.val = 1 := by
   refine ⟨congr_arg U8.val, fun h => U8.ext h⟩
 
 -- For converting BabyBear to U8, we can define a function that returns Option
@@ -146,6 +162,14 @@ lemma U2.eq_zero_iff (x : U2) : x = 0 ↔ x.val = 0 := by
 
 @[simp]
 lemma U2.eq_one_iff (x : U2) : x = 1 ↔ x.val = 1 := by
+  refine ⟨congr_arg U2.val, fun h => U2.ext h⟩
+
+@[simp]
+lemma U2.eq_zero_iff' (x : U2) : x = U2.zero ↔ x.val = 0 := by
+  refine ⟨congr_arg U2.val, fun h => U2.ext h⟩
+
+@[simp]
+lemma U2.eq_one_iff' (x : U2) : x = U2.one ↔ x.val = 1 := by
   refine ⟨congr_arg U2.val, fun h => U2.ext h⟩
 
 end U2

--- a/SP1Foundations/Word.lean
+++ b/SP1Foundations/Word.lean
@@ -39,8 +39,7 @@ def toFin32_U16 (w : Word U16) : Fin (2^32) :=
 lemma toNat_add_toNat (a b : Word (BabyBear)) :
     a.toNat + b.toNat = (a[0] + b[0]) + base * (a[1] + b[1]) := by
   simp [Word.toNat]
-  sorry
-  -- omega
+  omega
 
 theorem toFin32_U16_val {w : Word U16} : (w.toFin32_U16).val =
   w[0].val.val + w[1].val.val * 65536 := by
@@ -48,5 +47,36 @@ theorem toFin32_U16_val {w : Word U16} : (w.toFin32_U16).val =
 
 def isUInt32 (w : Word (BabyBear)) : Prop :=
   w[0].val < base ∧ w[1].val < base
+
+section Aesop
+
+-- Lemmas that are useful for `aesop` to add into context as needed
+-- marked safe so will always add them and not backtrack. Seems like they are never bad to add
+
+@[aesop safe forward]
+lemma val_fst_U2_lt (x : Word U2) : x[0].val.val = 0 ∨ x[0].val.val = 1 := by
+  convert x[0].in_range <;> simp [BabyBear.eq_one_iff_val_eq_one]
+
+@[aesop safe forward]
+lemma val_snd_U2_lt (x : Word U2) : x[1].val.val = 0 ∨ x[1].val.val = 1 := by
+  convert x[1].in_range <;> simp [BabyBear.eq_one_iff_val_eq_one]
+
+@[aesop safe forward]
+lemma val_fst_U8_lt (x : Word U8) : x[0].val.val < 256 := by
+  exact x[0].in_range
+
+@[aesop safe forward]
+lemma val_snd_U8_lt (x : Word U8) : x[1].val.val < 256 := by
+  exact x[1].in_range
+
+@[aesop safe forward]
+lemma val_fst_U16_lt (x : Word U16) : x[0].val.val < 65536 := by
+  exact x[0].in_range
+
+@[aesop safe forward]
+lemma val_snd_U16_lt (x : Word U16) : x[1].val.val < 65536 := by
+  exact x[1].in_range
+
+end Aesop
 
 end Word

--- a/SP1Operations/AddOperation.lean
+++ b/SP1Operations/AddOperation.lean
@@ -3,6 +3,7 @@ import SP1Foundations
 -- AddOperaton is not parameterized by a type `T` with `value` being `Word T`
 -- because AddOperation is used only under the assumption that its input and
 -- output limbs are all U16s.
+@[aesop safe cases]
 structure AddOperation where
   value : Word U16
 
@@ -53,24 +54,15 @@ theorem correct
 
       -- Since is_real = 1, substitute and apply 1 * x = x to get original constraints
       intro h_is_real
-      have is_real_val_eq_one : is_real.val = 1 := by aesop
-      rw [is_real_val_eq_one] at q1 q2
-
+      simp [is_real.eq_one_iff.1 h_is_real, sub_eq_zero, mul_eq_zero] at q1 q2
       simp [Word.toFin32_U16]
-      let _ : a[0].val.val < 65536 := a[0].in_range
-      let _ : a[1].val.val < 65536 := a[1].in_range
-      let _ : b[0].val.val < 65536 := b[0].in_range
-      let _ : b[1].val.val < 65536 := b[1].in_range
-      let _ : cols.value[0].val.val < 65536 := cols.value[0].in_range
-      let _ : cols.value[1].val.val < 65536 := cols.value[1].in_range
 
-      -- do basic arithmetic simplification
-      simp [sub_eq_zero, mul_eq_zero] at q1 q2
+      -- Cases on whether the lower limb led to a carry or not
       cases q1 with | inl qq1 => ?_ | inr qq1 => ?_
       all_goals
       · rw [qq1] at q2
-        simp only [Fin.mul_def, Fin.sub_def, Fin.add_def, Fin.ext_iff] at *
-        simp [BabyBearPrime, UInt32.size] at *
-        omega
+        simp only [Fin.mul_def, Fin.sub_def, Fin.add_def, Fin.ext_iff, BabyBearPrime, UInt32.size] at *
+        -- Run `aesop` with semi-safe access to the `omega` tactic
+        aesop (add 50% tactic (by omega))
 
 end AddOperation


### PR DESCRIPTION
Add some basic `aesop` lemmas to try and auto add bounds such as `x < 256` for `x` a u8 baby-bear value