### PR TITLE
feat: unified way to represent unsigned ints

### DIFF
--- a/SP1Chips/AddChip.lean
+++ b/SP1Chips/AddChip.lean
@@ -75,7 +75,7 @@ Receives: AirInteraction { values: [state.shard, (((16384 * state.clk_high_limb)
 
 -/
 
-def sp1_add (chip : AddChip) (constraints : chip.constraints) (h_is_real : chip.is_real = U1.one) (rd rs1 rs2 : regidx) (read_b : chip.adapter.read_b_fun rs1) (read_c : chip.adapter.read_c_fun rs2) : SailM Unit := do
+def sp1_add (chip : AddChip) (constraints : chip.constraints) (h_is_real : chip.is_real = 1) (rd rs1 rs2 : regidx) (read_b : chip.adapter.read_b_fun rs1) (read_c : chip.adapter.read_c_fun rs2) : SailM Unit := do
     -- Model YOUR implementation's behavior
     writeReg Register.nextPC (BitVec.addInt (← readReg Register.PC) 4)
     /- let ⟨rs1_val, ⟨rs2_val, matching⟩⟩ ← chip.read rs1 rs2 -/
@@ -96,7 +96,7 @@ def sp1_add (chip : AddChip) (constraints : chip.constraints) (h_is_real : chip.
   let _ ← execute_RTYPE rs2 rs1 rd rop.ADD
   pure ()
 
-theorem sp1_add_implies_spec_add (chip : AddChip) (constraints : chip.constraints) (h_is_real : chip.is_real = U1.one) (rd rs1 rs2 : regidx) (read_b : chip.adapter.read_b_fun rs1) (read_c : chip.adapter.read_c_fun rs2) (s : PreSail.SequentialState RegisterType trivialChoiceSource) :
+theorem sp1_add_implies_spec_add (chip : AddChip) (constraints : chip.constraints) (h_is_real : chip.is_real = 1) (rd rs1 rs2 : regidx) (read_b : chip.adapter.read_b_fun rs1) (read_c : chip.adapter.read_c_fun rs2) (s : PreSail.SequentialState RegisterType trivialChoiceSource) :
   let res := (sp1_add chip constraints h_is_real rd rs1 rs2 read_b read_c).run s
   let res_spec := (spec_add rd rs1 rs2).run s
   res = res_spec :=

--- a/SP1Chips/JalChip.lean
+++ b/SP1Chips/JalChip.lean
@@ -8,7 +8,7 @@ namespace exp
 
 -- Simple experiment with StateM Int to prove consecutive reads are equivalent
 theorem simple_consecutive_reads :
-  (do let x ← StateT.get; let y ← StateT.get; pure (x, y) : StateM Int (Int × Int)) = 
+  (do let x ← StateT.get; let y ← StateT.get; pure (x, y) : StateM Int (Int × Int)) =
   (do let x ← StateT.get; pure (x, x) : StateM Int (Int × Int)) := by
   -- Work directly with function extensionality
   funext s
@@ -17,12 +17,12 @@ theorem simple_consecutive_reads :
 
 -- More general theorem about reads with no interfering operations
 theorem reads_with_pure_operations :
-  (do 
+  (do
     let x ← StateT.get
     let _ ← pure ()  -- Some pure operation that doesn't change state
     let y ← StateT.get
-    pure (x, y) : StateM Int (Int × Int)) = 
-  (do 
+    pure (x, y) : StateM Int (Int × Int)) =
+  (do
     let x ← StateT.get
     let _ ← pure ()
     pure (x, x) : StateM Int (Int × Int)) := by
@@ -31,9 +31,9 @@ theorem reads_with_pure_operations :
   rfl
 
 -- Simple working version of monadic substitution
-theorem simple_monadic_subst {α β : Type} {m : Type → Type} [Monad m] 
+theorem simple_monadic_subst {α β : Type} {m : Type → Type} [Monad m]
   (ma : m α) (f : α → β) (mb : m β)
-  (h : f <$> ma = mb) : 
+  (h : f <$> ma = mb) :
   (do let a ← ma; pure (f a)) = mb := by
   rw [← bind_pure_comp, ← map_bind, h]
 
@@ -59,7 +59,7 @@ end JalChip
 def sp1_jal
   (chip : JalChip)
   (constraints : chip.constraints)
-  (h_is_real : chip.is_real = U1.one)
+  (h_is_real : chip.is_real = 1)
   (rd : regidx)
   (imm : BitVec 21)
   (read_b : chip.adapter.read_jal_b_fun imm)
@@ -87,7 +87,7 @@ def runSuccessState {α : Type} (m : SailM α) (s : SequentialState RegisterType
 theorem sp1_jal_implies_spec_jal
   (chip : JalChip)
   (constraints : chip.constraints)
-  (h_is_real : chip.is_real = U1.one)
+  (h_is_real : chip.is_real = 1)
   (rd : regidx)
   (imm : BitVec 21)
   (read_b : chip.adapter.read_jal_b_fun imm)
@@ -109,17 +109,17 @@ theorem sp1_jal_implies_spec_jal
 
     simp [ext_control_check_pc]
     simp [get_next_pc, set_next_pc, bits_of_virtaddr]
-    
+
     -- Now use trusted_jmp to replace bit_to_bool expressions
     simp [trusted_jmp]
     -- Now a_1 should be replaced with false everywhere
-    
+
     -- -- Use read_b to substitute (a + sign_extend imm) with chip.adapter.b.toBV32_U16
     -- -- read_b tells us: (fun x ↦ x + sign_extend imm) <$> readReg Register.PC = pure chip.adapter.b.toBV32_U16
     -- -- This means: for the specific PC value `a`, we have (a + sign_extend imm) = chip.adapter.b.toBV32_U16
     -- -- Let's extract this equality and use it
     -- have h_pc_eq : (fun x ↦ x + sign_extend imm) <$> readReg Register.PC = pure chip.adapter.b.toBV32_U16 := read_b
-    -- 
+    --
     -- -- We need to show that the bind where we read PC and then add imm is equivalent to using b directly
     -- -- Let's try to use our monadic substitution lemma
     -- conv_rhs =>

--- a/SP1Foundations/Unsigned.lean
+++ b/SP1Foundations/Unsigned.lean
@@ -29,50 +29,71 @@ lemma base_eq_inv_baseInv : base = baseInv⁻¹ := by
 
 end base
 
-section U16
+/-- General definition that can be used to define `U1`, `U8`, and `U16`.
+Allows writing unified lemmas for all three definitions. -/
+structure BoundedBabyBear (bound : ℕ) extends BabyBear where
+  in_range : val < bound
 
-structure U16 extends BabyBear where
-  in_u16_range : val < base.val
+namespace BoundedBabyBear
 
-def U16.ofNat (x : Nat) : U16 := ⟨x % base, by simp; exact Nat.mod_lt (x := x % BabyBearPrime) ((by decide) : 65536 > 0)⟩
+def ofNat (bound_dec x : ℕ) : BoundedBabyBear bound_dec.succ where
+  val := (x % bound_dec.succ) % BabyBearPrime
+  isLt := Nat.mod_lt _ Nat.succ_pos'
+  in_range := Nat.mod_lt_of_lt (Nat.mod_lt _ Nat.succ_pos')
 
-@[reducible]
-def U16.zero : U16 := { (0 : BabyBear) with in_u16_range := by simp [base] }
-@[reducible]
-def U16.one : U16 := { (1 : BabyBear) with in_u16_range := by simp [base] }
+/-- If the bound is at least `1` then `boundedBabyBear` has a natural `0`. -/
+def boundedBabyBear.zero (bound_dec : ℕ) : BoundedBabyBear bound_dec.succ where
+  in_range := by simp
+  __ := (0 : BabyBear)
 
-instance : Coe U16 BabyBear where
-  coe x := x.toFin
+/-- If the bound is at least `2` then `boundedBabyBear` has a natural `1`. -/
+def boundedBabyBear.one (bound_dec_dec : ℕ) : BoundedBabyBear (bound_dec_dec.succ.succ) where
+  in_range := by simp
+  __ := (1 : BabyBear)
 
-end U16
+instance (bound_dec : ℕ) : Zero (BoundedBabyBear bound_dec.succ) := ⟨boundedBabyBear.zero _⟩
+instance (bound_dec_dec : ℕ) : One (BoundedBabyBear bound_dec_dec.succ.succ) := ⟨boundedBabyBear.one _⟩
 
-section U8
+/-- Should only make an actual instance for special cases. -/
+def coe_of_le {bound bound' : ℕ} (h : bound ≤ bound') :
+    Coe (BoundedBabyBear bound) (BoundedBabyBear bound') where
+  coe x := { in_range := lt_of_lt_of_le x.in_range h, __ := x }
 
-structure U8 extends U16 where
-  in_u8_range : val < 256
+variable {bound : ℕ}
 
-@[reducible]
-def U8.zero : U8 := { U16.zero with in_u8_range := by simp }
-@[reducible]
-def U8.one : U8 := { U16.one with in_u8_range := by simp }
+def toBabyBear (x : BoundedBabyBear bound) : BabyBear where __ := x
 
-instance : Coe U8 BabyBear where
-  coe x := x.toFin
+@[simp] lemma toBabyBear_zero : (0 : BoundedBabyBear bound.succ).toBabyBear = 0 := rfl
+@[simp] lemma toBabyBear_one : (1 : BoundedBabyBear bound.succ.succ).toBabyBear = 1 := rfl
 
-end U8
+@[simp] lemma toFin_zero : (0 : BoundedBabyBear bound.succ).toFin = 0 := rfl
+@[simp] lemma toFin_one : (1 : BoundedBabyBear bound.succ.succ).toFin = 1 := rfl
 
-section U1
+lemma toFin_inj (x y : BoundedBabyBear bound) : x.toFin = y.toFin ↔ x = y := sorry
 
--- U1 type for bits
-structure U1 extends U8 where
-  in_u1_range : val = 0 ∨ val = 1
+lemma toFin_eq_iff (x : BoundedBabyBear bound) (y : Fin BabyBearPrime) : x.toFin = y ↔ x.val = y.val := by
+  erw [Fin.ext_iff]
 
-@[reducible]
-def U1.one : U1 := { U8.one with in_u1_range := by simp }
-@[reducible]
-def U1.zero : U1 := { U8.zero with in_u1_range := by simp }
+@[simp] lemma eq_zero_iff (x : BoundedBabyBear bound.succ) : x = 0 ↔ x.val = 0 := by
+  rw [Fin.val_eq_zero_iff, ← toFin_zero, toFin_inj]
 
-instance : Coe U1 BabyBear where
-  coe x := x.toFin
+@[simp] lemma eq_one_iff (x : BoundedBabyBear bound.succ.succ) : x = 1 ↔ x.val = 1 := by
+  sorry
 
-end U1
+@[simp] lemma val_toBabyBear (x : BoundedBabyBear bound) : (x.toBabyBear : ℕ) = x.val := rfl
+
+end BoundedBabyBear
+
+abbrev U16 := BoundedBabyBear 65536
+abbrev U8 := BoundedBabyBear 256
+abbrev U1 := BoundedBabyBear 2
+
+instance : Coe U16 BabyBear where coe := BoundedBabyBear.toBabyBear
+instance : Coe U8 BabyBear where coe := BoundedBabyBear.toBabyBear
+instance : Coe U1 BabyBear where coe := BoundedBabyBear.toBabyBear
+
+instance : Coe U1 U8 := BoundedBabyBear.coe_of_le <| by omega
+instance : Coe U8 U16 := BoundedBabyBear.coe_of_le <| by omega
+
+def U1.in_range' (x : U1) : x.val = 0 ∨ x.val = 1 := by
+  have := x.in_range; omega

--- a/SP1Foundations/Word.lean
+++ b/SP1Foundations/Word.lean
@@ -30,15 +30,15 @@ def toFin32_BB (w : Word BabyBear) : Fin (2^32) :=
 
 def toFin32_U16 (w : Word U16) : Fin (2^32) :=
   ⟨w[0].val + w[1].val * 65536, by
-    have wn0_in_range := w[0].in_u16_range
-    have wn1_in_range := w[1].in_u16_range
+    have wn0_in_range := w[0].in_range
+    have wn1_in_range := w[1].in_range
     simp at *
     omega⟩
 
-def toBV32_U16 (w : Word U16) : BitVec BIT_WIDTH := 
+def toBV32_U16 (w : Word U16) : BitVec BIT_WIDTH :=
   BitVec.ofNatLT (w[0].val + w[1].val * base) (by
-    have _ := w[0].in_u16_range
-    have _ := w[1].in_u16_range
+    have _ := w[0].in_range
+    have _ := w[1].in_range
     simp at *
     omega)
 
@@ -63,28 +63,34 @@ section Aesop
 -- marked safe so will always add them and not backtrack. Seems like they are never bad to add
 
 @[aesop safe forward]
-lemma val_fst_U1_lt (x : Word U1) : x[0].val = 0 ∨ x[0].val = 1 := by
-  convert x[0].in_u1_range
+lemma val_fst_boundedBabyBear_lt {bound : ℕ} (x : Word (BoundedBabyBear bound)) : x[0].val < bound := x[0].in_range
 
 @[aesop safe forward]
-lemma val_snd_U1_lt (x : Word U1) : x[1].val = 0 ∨ x[1].val = 1 := by
-  convert x[1].in_u1_range
+lemma val_snd_boundedBabyBear_lt {bound : ℕ} (x : Word (BoundedBabyBear bound)) : x[1].val < bound := x[1].in_range
 
-@[aesop safe forward]
-lemma val_fst_U8_lt (x : Word U8) : x[0].val < 256 := by
-  exact x[0].in_u8_range
+-- @[aesop safe forward]
+-- lemma val_fst_U1_lt (x : Word U1) : x[0].val = 0 ∨ x[0].val = 1 := by
+--   convert x[0].in_range
 
-@[aesop safe forward]
-lemma val_snd_U8_lt (x : Word U8) : x[1].val < 256 := by
-  exact x[1].in_u8_range
+-- @[aesop safe forward]
+-- lemma val_snd_U1_lt (x : Word U1) : x[1].val = 0 ∨ x[1].val = 1 := by
+--   convert x[1].in_range
 
-@[aesop safe forward]
-lemma val_fst_U16_lt (x : Word U16) : x[0].val < 65536 := by
-  exact x[0].in_u16_range
+-- @[aesop safe forward]
+-- lemma val_fst_U8_lt (x : Word U8) : x[0].val < 256 := by
+--   exact x[0].in_range
 
-@[aesop safe forward]
-lemma val_snd_U16_lt (x : Word U16) : x[1].val < 65536 := by
-  exact x[1].in_u16_range
+-- @[aesop safe forward]
+-- lemma val_snd_U8_lt (x : Word U8) : x[1].val < 256 := by
+--   exact x[1].in_range
+
+-- @[aesop safe forward]
+-- lemma val_fst_U16_lt (x : Word U16) : x[0].val < 65536 := by
+--   exact x[0].in_range
+
+-- @[aesop safe forward]
+-- lemma val_snd_U16_lt (x : Word U16) : x[1].val < 65536 := by
+--   exact x[1].in_range
 
 end Aesop
 

--- a/SP1Operations/Add4Operation.lean
+++ b/SP1Operations/Add4Operation.lean
@@ -11,7 +11,7 @@ def Add4Operation.spec
   (cc : Word U16)
   (d : Word U16)
   (is_real : U1) : Prop :=
-    is_real = U1.one →
+    is_real = 1 →
     a.toFin32_U16 + b.toFin32_U16 + cc.toFin32_U16 + d.toFin32_U16 = cols.value.toFin32_U16
 
 def Add4Operation.constraints
@@ -21,8 +21,8 @@ def Add4Operation.constraints
     (cc : Word U16)
     (d : Word U16)
     (is_real : U1): Prop :=
-    (is_real = U1.one → ((((((a[0].val + b[0].val) + cc[0].val) + d[0].val) - cols.value[0].val) + 0) * 2013235201) < 256) -- checking this is < 8 bytes
-    ∧ (is_real = U1.one → ((((((a[1].val + b[1].val) + cc[1].val) + d[1].val) - cols.value[1].val) + ((((((a[0].val + b[0].val) + cc[0].val) + d[0].val) - cols.value[0].val) + 0) * 2013235201)) * 2013235201) < 256)
+    (is_real = 1 → ((((((a[0].val + b[0].val) + cc[0].val) + d[0].val) - cols.value[0].val) + 0) * 2013235201) < 256) -- checking this is < 8 bytes
+    ∧ (is_real = 1 → ((((((a[1].val + b[1].val) + cc[1].val) + d[1].val) - cols.value[1].val) + ((((((a[0].val + b[0].val) + cc[0].val) + d[0].val) - cols.value[0].val) + 0) * 2013235201)) * 2013235201) < 256)
 
 def Add4Operation.constraints'
     (cols : Add4Operation)
@@ -34,8 +34,8 @@ def Add4Operation.constraints'
     let carry0 : BabyBear := 0
     let carry1 : BabyBear := (a[0].val + b[0].val + cc[0].val + d[0].val - cols.value[0].val + carry0) * baseInv
     let carry2 : BabyBear := (a[1].val + b[1].val + cc[1].val + d[1] - cols.value[1].val + carry1) * baseInv
-    (is_real = U1.one → carry1 < 256)
-    ∧ (is_real = U1.one → carry2 < 256)
+    (is_real = 1 → carry1 < 256)
+    ∧ (is_real = 1 → carry2 < 256)
 
 theorem helper1 {n : Nat} {a : Nat} {ha : a < n} {x : Nat} : (Fin.mk a ha) < x → a % n < x := by sorry
 
@@ -68,16 +68,16 @@ theorem Add4Operation.correct (cols : Add4Operation)
     simp at q1 q2
 
     -- Extract bounds on values
-    -- have a0_bound : a[0].val.val < 65536 := a[0].in_range
-    -- have a1_bound : a[1].val.val < 65536 := a[1].in_range
-    -- have b0_bound : b[0].val.val < 65536 := b[0].in_range
-    -- have b1_bound : b[1].val.val < 65536 := b[1].in_range
-    -- have c0_bound : cc[0].val.val < 65536 := cc[0].in_range
-    -- have c1_bound : cc[1].val.val < 65536 := cc[1].in_range
-    -- have d0_bound : d[0].val.val < 65536 := d[0].in_range
-    -- have d1_bound : d[1].val.val < 65536 := d[1].in_range
-    -- have v0_bound : cols.value[0].val.val < 65536 := cols.value[0].in_range
-    -- have v1_bound : cols.value[1].val.val < 65536 := cols.value[1].in_range
+    -- have a0_bound : a[0].val < 65536 := a[0].in_range
+    -- have a1_bound : a[1].val < 65536 := a[1].in_range
+    -- have b0_bound : b[0].val < 65536 := b[0].in_range
+    -- have b1_bound : b[1].val < 65536 := b[1].in_range
+    -- have c0_bound : cc[0].val < 65536 := cc[0].in_range
+    -- have c1_bound : cc[1].val < 65536 := cc[1].in_range
+    -- have d0_bound : d[0].val < 65536 := d[0].in_range
+    -- have d1_bound : d[1].val < 65536 := d[1].in_range
+    -- have v0_bound : cols.value[0].val < 65536 := cols.value[0].in_range
+    -- have v1_bound : cols.value[1].val < 65536 := cols.value[1].in_range
 
     simp [Word.toFin32_U16]
     simp [Fin.add_def, Fin.mul_def, Fin.sub_def, add_assoc] at *

--- a/SP1Operations/AddOperation.lean
+++ b/SP1Operations/AddOperation.lean
@@ -14,7 +14,7 @@ def spec
   (a : Word U16)
   (b : Word U16)
   (is_real : U1) : Prop :=
-    is_real = U1.one →
+    is_real = 1 →
     a.toBV32_U16 + b.toBV32_U16 = cols.value.toBV32_U16
 
 /- def constraints (cols : AddOperation) -/
@@ -66,12 +66,12 @@ theorem correct
       simp [sub_eq_zero, mul_eq_zero] at q1 q2
       simp [Word.toBV32_U16, BitVec.ofNatLT]
 
-      let i1 := a[0].in_u16_range
-      let i2 := a[1].in_u16_range
-      let i3 := b[0].in_u16_range
-      let i4 := b[1].in_u16_range
-      let i5 := cols.value[0].in_u16_range
-      let i6 := cols.value[1].in_u16_range
+      let i1 := a[0].in_range
+      let i2 := a[1].in_range
+      let i3 := b[0].in_range
+      let i4 := b[1].in_range
+      let i5 := cols.value[0].in_range
+      let i6 := cols.value[1].in_range
       simp [base] at i1 i2 i3 i4 i5 i6
 
       -- Cases on whether the lower limb led to a carry or not
@@ -80,7 +80,7 @@ theorem correct
           rw [qq1] at q2
           simp [Fin.mul_def, Fin.sub_def, Fin.add_def, Fin.ext_iff, BabyBearPrime] at *
           omega
-      | inr qq1 => 
+      | inr qq1 =>
           rw [qq1] at q2
           simp [Fin.mul_def, Fin.sub_def, Fin.add_def, Fin.ext_iff, BabyBearPrime] at *
           omega

--- a/SP1Operations/MSBOperation.lean
+++ b/SP1Operations/MSBOperation.lean
@@ -7,16 +7,16 @@ def U16MSBOperation.spec
   (cols : U16MSBOperation)
   (a : U16)
   (is_real : U1) : Prop :=
-    is_real = U1.one →
+    is_real = 1 →
     -- MSB is 1 if a >= 2^15, otherwise 0
-    (a.val.val < 32768 ∧ cols.msb = 0) ∨
-    (a.val.val ≥ 32768 ∧ cols.msb = 1)
+    (a.val < 32768 ∧ cols.msb = 0) ∨
+    (a.val ≥ 32768 ∧ cols.msb = 1)
 
 def U16MSBOperation.constraints
   (cols : U16MSBOperation)
   (a : U16)
   (is_real : U1) : Prop :=
-    is_real = U1.one →
+    is_real = 1 →
     -- (2 * a) - (cols.msb * 65536) must be within U16 range
     -- This effectively checks: 2*a - msb*2^16 < 2^16
     -- When msb=0: 2*a < 2^16 (true for a < 2^15)
@@ -30,10 +30,10 @@ theorem U16MSBOperation.correct (cols : U16MSBOperation)
   by
     intro h_constraint
     intro h_is_real
-    -- Since is_real = U1.one, extract the original constraint
+    -- Since is_real = 1, extract the original constraint
     have orig_constraint : ((2 : BabyBear) * a.val) - (cols.msb.val * (65536 : BabyBear)) < (base : BabyBear) := h_constraint h_is_real
     -- Show the spec holds
-    show (a.val.val < 32768 ∧ cols.msb = 0) ∨ (a.val.val ≥ 32768 ∧ cols.msb = 1)
+    show (a.val < 32768 ∧ cols.msb = 0) ∨ (a.val ≥ 32768 ∧ cols.msb = 1)
     -- Get the ranges we need
     have a_in_range := a.in_range
 
@@ -45,7 +45,7 @@ theorem U16MSBOperation.correct (cols : U16MSBOperation)
       have h_msb_val : cols.msb.val = 0 := h_zero
       rw [h_msb_val] at orig_constraint
       constructor
-      · -- Show a.val.val < 32768
+      · -- Show a.val < 32768
         -- orig_constraint : 2 * a.val - 0 * 65536 < 65536
         -- Note: 0 : BabyBear is actually Fin.mk 0, so we need to handle this carefully
         have h_simplify : (2 : BabyBear) * a.val - (0 : BabyBear) * (65536 : BabyBear) = (2 : BabyBear) * a.val := by
@@ -56,21 +56,21 @@ theorem U16MSBOperation.correct (cols : U16MSBOperation)
           simp only [Fin.lt_iff_val_lt_val] at orig_constraint
           exact orig_constraint
         -- Show that 2 * a.val doesn't wrap
-        have h_no_wrap : (2 * a.val).val = 2 * a.val.val := by
+        have h_no_wrap : (2 * a.val).val = 2 * a.val := by
           simp only [Fin.val_mul]
           apply Nat.mod_eq_of_lt
-          have : a.val.val < base := a_in_range
+          have : a.val < base := a_in_range
           simp [BabyBearPrime, base] at *
           omega
         rw [h_no_wrap] at h_constraint_nat
-        -- From 2 * a.val.val < 65536, deduce a.val.val < 32768
+        -- From 2 * a.val < 65536, deduce a.val < 32768
         omega
 
       · -- Show cols.msb = 0
-        -- Since cols.msb.val = 0 and cols.msb has type U1, it must equal U1.zero
-        have : cols.msb = U1.zero := by
+        -- Since cols.msb.val = 0 and cols.msb has type U1, it must equal 0
+        have : cols.msb = 0 := by
           ext
-          simp [U1.zero]
+          simp [0]
           exact h_zero
         rw [this]
         rfl
@@ -81,8 +81,8 @@ theorem U16MSBOperation.correct (cols : U16MSBOperation)
       have h_msb_val : cols.msb.val = 1 := h_one
       rw [h_msb_val] at orig_constraint
       constructor
-      · -- Show a.val.val ≥ 32768
-        -- By contradiction: assume a.val.val < 32768
+      · -- Show a.val ≥ 32768
+        -- By contradiction: assume a.val < 32768
         by_contra h_not_ge
         push_neg at h_not_ge
 
@@ -96,77 +96,77 @@ theorem U16MSBOperation.correct (cols : U16MSBOperation)
           simp only [Fin.lt_iff_val_lt_val] at orig_constraint
           exact orig_constraint
 
-        -- When a.val.val < 32768, we have 2 * a.val.val < 65536
-        have h_2a_small : 2 * a.val.val < 65536 := by
+        -- When a.val < 32768, we have 2 * a.val < 65536
+        have h_2a_small : 2 * a.val < 65536 := by
           omega
 
-        -- So (2 * a.val) as BabyBear has value 2 * a.val.val (no wrap)
-        have h_2a_val : ((2 : BabyBear) * a.val).val = 2 * a.val.val := by
+        -- So (2 * a.val) as BabyBear has value 2 * a.val (no wrap)
+        have h_2a_val : ((2 : BabyBear) * a.val).val = 2 * a.val := by
           simp only [Fin.val_mul]
           apply Nat.mod_eq_of_lt
-          have : a.val.val < base := a_in_range
+          have : a.val < base := a_in_range
           simp [BabyBearPrime, base] at *
           omega
 
-        -- Since 2 * a.val.val < 65536, the subtraction wraps around
+        -- Since 2 * a.val < 65536, the subtraction wraps around
         -- In modular arithmetic, when x < y, x - y ≡ x + p - y (mod p)
         have h_sub_wrap : ((2 : BabyBear) * a.val - (65536 : BabyBear)).val =
-                          2 * a.val.val + BabyBearPrime - 65536 := by
+                          2 * a.val + BabyBearPrime - 65536 := by
           simp only [Fin.sub_def]
           rw [h_2a_val]
-          -- We have 2 * a.val.val < 65536 < BabyBearPrime
-          -- So (BabyBearPrime - 65536 + 2 * a.val.val) % BabyBearPrime = BabyBearPrime - 65536 + 2 * a.val.val
+          -- We have 2 * a.val < 65536 < BabyBearPrime
+          -- So (BabyBearPrime - 65536 + 2 * a.val) % BabyBearPrime = BabyBearPrime - 65536 + 2 * a.val
           have h1 : (65536 : BabyBear).val = 65536 := rfl
           simp only [h1]
-          -- Since 2 * a.val.val < 65536, we have BabyBearPrime - 65536 + 2 * a.val.val < BabyBearPrime
-          have h_lt : BabyBearPrime - 65536 + 2 * a.val.val < BabyBearPrime := by
+          -- Since 2 * a.val < 65536, we have BabyBearPrime - 65536 + 2 * a.val < BabyBearPrime
+          have h_lt : BabyBearPrime - 65536 + 2 * a.val < BabyBearPrime := by
             simp [BabyBearPrime]
             omega
           rw [Nat.mod_eq_of_lt h_lt]
-          -- Now we need to show BabyBearPrime - 65536 + 2 * a.val.val = 2 * a.val.val + BabyBearPrime - 65536
+          -- Now we need to show BabyBearPrime - 65536 + 2 * a.val = 2 * a.val + BabyBearPrime - 65536
           simp [BabyBearPrime]
           ring
 
         -- The wrapped value doesn't need modulo
-        have h_no_mod : (2 * a.val.val + BabyBearPrime - 65536) % BabyBearPrime =
-                        2 * a.val.val + BabyBearPrime - 65536 := by
+        have h_no_mod : (2 * a.val + BabyBearPrime - 65536) % BabyBearPrime =
+                        2 * a.val + BabyBearPrime - 65536 := by
           apply Nat.mod_eq_of_lt
           simp [BabyBearPrime]
           omega
 
         rw [h_sub_wrap] at h_constraint_nat
-        -- Now h_constraint_nat says: 2 * a.val.val + BabyBearPrime - 65536 < 65536
-        -- This means BabyBearPrime < 131072 - 2 * a.val.val ≤ 131072
+        -- Now h_constraint_nat says: 2 * a.val + BabyBearPrime - 65536 < 65536
+        -- This means BabyBearPrime < 131072 - 2 * a.val ≤ 131072
         have : BabyBearPrime < 131072 := by
           omega
         -- But BabyBearPrime = 2013265921 > 131072, contradiction
         norm_num [BabyBearPrime] at this
 
       · -- Show cols.msb = 1
-        -- Since cols.msb.val = 1 and cols.msb has type U1, it must equal U1.one
-        have : cols.msb = U1.one := by
+        -- Since cols.msb.val = 1 and cols.msb has type U1, it must equal 1
+        have : cols.msb = 1 := by
           ext
-          simp only [U1.one]
+          simp only [1]
           simp [h_one]
         rw [this]
         rfl
 
 -- Example demonstrating U1 usage with numeric literals
 example : U16MSBOperation := {
-  msb := 1  -- Can write 1 directly instead of U1.one
+  msb := 1  -- Can write 1 directly instead of 1
 }
 
 example : U16MSBOperation := {
-  msb := 0  -- Can write 0 directly instead of U1.zero
+  msb := 0  -- Can write 0 directly instead of 0
 }
 
 -- Example showing the spec works with numeric literals
-example (a : U16) (h : a.val.val = 40000) :
-  U16MSBOperation.spec ⟨1⟩ a U1.one := by
+example (a : U16) (h : a.val = 40000) :
+  U16MSBOperation.spec ⟨1⟩ a 1 := by
   intro h_is_real
   right
   constructor
-  · -- Show a.val.val ≥ 32768
+  · -- Show a.val ≥ 32768
     rw [h]
     norm_num
   · -- Show msb = 1

--- a/SP1Operations/SubOperation.lean
+++ b/SP1Operations/SubOperation.lean
@@ -8,7 +8,7 @@ namespace SubOperation
 /-- `SubOperation` should result in wrapping addition of the outputs.
 Note that we ignore `is_real` for now. -/
 def spec (cols : SubOperation) (a b : Word U16) (is_real : U1) : Prop :=
-  is_real = U1.one → a.toFin32_U16 - b.toFin32_U16 = cols.value.toFin32_U16
+  is_real = 1 → a.toFin32_U16 - b.toFin32_U16 = cols.value.toFin32_U16
 
 /-- Constraints on `SubOperation` as extracted from the source code:
 Asserting expr 3: `(is_real * (is_real - 1))`
@@ -54,12 +54,12 @@ theorem correct [Fact (Nat.Prime p)] (cols : SubOperation)
   simp [Word.toFin32_U16]
 
   -- Extract the range constraint in U16
-  let _ : a[0].val.val < 65536 := a[0].in_range
-  let _ : b[0].val.val < 65536 := b[0].in_range
-  let _ : a[1].val.val < 65536 := a[1].in_range
-  let _ : b[1].val.val < 65536 := b[1].in_range
-  let _ : cols.value[0].val.val < 65536 := cols.value[0].in_range
-  let _ : cols.value[1].val.val < 65536 := cols.value[1].in_range
+  let _ : a[0].val < 65536 := a[0].in_range
+  let _ : b[0].val < 65536 := b[0].in_range
+  let _ : a[1].val < 65536 := a[1].in_range
+  let _ : b[1].val < 65536 := b[1].in_range
+  let _ : cols.value[0].val < 65536 := cols.value[0].in_range
+  let _ : cols.value[1].val < 65536 := cols.value[1].in_range
 
   -- Split on whether the lower limb addition causes a carry
   cases h1 with | inl h1 => ?_ | inr h1 => ?_


### PR DESCRIPTION
PR to implement all unsigned integers as special cases of a `BoundedBabyBear` type:

```
structure BoundedBabyBear (bound : ℕ) extends BabyBear where
  in_range : val < bound

abbrev U16 := BoundedBabyBear 65536
abbrev U8 := BoundedBabyBear 256
abbrev U1 := BoundedBabyBear 2
```

In theory this should allow better automation and makes sure that all of them get the same set of lemms (rather than some being occasionally forgotten. Some proofs are broken then but it seems like they were already broken in the first place. Simple examples like add op and is_zero op are simplified.