### PR TITLE
build: optimize imports for build time

### DIFF
--- a/SP1Chips/Add/Constraints.lean
+++ b/SP1Chips/Add/Constraints.lean
@@ -1,4 +1,6 @@
-import SP1Operations
+import SP1Operations.Operation.AddOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.RTypeReader
 
 namespace Add
 

--- a/SP1Chips/AddChip.lean
+++ b/SP1Chips/AddChip.lean
@@ -1,5 +1,7 @@
 import SP1Foundations
-import SP1Operations
+import SP1Operations.Operation.AddOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.RTypeReader
 import LeanRV64IM.RiscvInstsEnd
 
 import SP1Chips.Add.Constraints

--- a/SP1Chips/Addi/Constraints.lean
+++ b/SP1Chips/Addi/Constraints.lean
@@ -1,4 +1,6 @@
-import SP1Operations
+import SP1Operations.Operation.AddOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ITypeReader
 
 namespace Addi
 

--- a/SP1Chips/AddiChip.lean
+++ b/SP1Chips/AddiChip.lean
@@ -1,2 +1,4 @@
-import SP1Operations
+import SP1Operations.Operation.AddOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ITypeReader
 import SP1Chips.Addi.Constraints

--- a/SP1Chips/Addw/Constraints.lean
+++ b/SP1Chips/Addw/Constraints.lean
@@ -1,4 +1,6 @@
-import SP1Operations
+import SP1Operations.Operation.AddwOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ALUTypeReader
 
 namespace Addw
 

--- a/SP1Chips/AddwChip.lean
+++ b/SP1Chips/AddwChip.lean
@@ -1,2 +1,4 @@
-import SP1Operations
+import SP1Operations.Operation.AddwOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ALUTypeReader
 import SP1Chips.Addw.Constraints

--- a/SP1Chips/Bitwise/Constraints.lean
+++ b/SP1Chips/Bitwise/Constraints.lean
@@ -1,4 +1,6 @@
-import SP1Operations
+import SP1Operations.Operation.BitwiseU16Operation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ALUTypeReader
 
 namespace Bitwise
 

--- a/SP1Chips/BitwiseChip.lean
+++ b/SP1Chips/BitwiseChip.lean
@@ -1,4 +1,6 @@
-import SP1Operations
+import SP1Operations.Operation.BitwiseU16Operation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ALUTypeReader
 import SP1Chips.Bitwise.Constraints
 
 -- import SP1Operations

--- a/SP1Chips/DivRem/Constraints.lean
+++ b/SP1Chips/DivRem/Constraints.lean
@@ -1,4 +1,11 @@
-import SP1Operations
+import SP1Operations.Operation.MulOperation
+import SP1Operations.Operation.AddOperation
+import SP1Operations.Compare.IsEqualWordOperation
+import SP1Operations.Compare.IsZeroWordOperation
+import SP1Operations.Compare.LtOperationUnsigned
+import SP1Operations.Operation.U16MSBOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ALUTypeReader
 
 namespace DivRem
 

--- a/SP1Chips/DivRemChip.lean
+++ b/SP1Chips/DivRemChip.lean
@@ -1,2 +1,9 @@
-import SP1Operations
+import SP1Operations.Operation.MulOperation
+import SP1Operations.Operation.AddOperation
+import SP1Operations.Compare.IsEqualWordOperation
+import SP1Operations.Compare.IsZeroWordOperation
+import SP1Operations.Compare.LtOperationUnsigned
+import SP1Operations.Operation.U16MSBOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ALUTypeReader
 import SP1Chips.DivRem.Constraints

--- a/SP1Chips/JalChip.lean
+++ b/SP1Chips/JalChip.lean
@@ -1,4 +1,4 @@
-import SP1Operations
+import SP1Operations.Operation.AddOperation
 
 namespace JalChip
 

--- a/SP1Chips/Jalr/Constraints.lean
+++ b/SP1Chips/Jalr/Constraints.lean
@@ -1,4 +1,6 @@
-import SP1Operations
+import SP1Operations.Operation.AddOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ITypeReader
 
 namespace Jalr
 

--- a/SP1Chips/JalrChip.lean
+++ b/SP1Chips/JalrChip.lean
@@ -1,5 +1,7 @@
 import SP1Foundations
-import SP1Operations
+import SP1Operations.Operation.AddOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ITypeReader
 import LeanRV64IM.RiscvInstsEnd
 
 import SP1Chips.Jalr.Constraints

--- a/SP1Chips/Lt/Constraints.lean
+++ b/SP1Chips/Lt/Constraints.lean
@@ -1,4 +1,6 @@
-import SP1Operations
+import SP1Operations.Compare.LtOperationSigned
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ALUTypeReader
 
 namespace Lt
 

--- a/SP1Chips/LtChip.lean
+++ b/SP1Chips/LtChip.lean
@@ -1,2 +1,4 @@
-import SP1Operations
+import SP1Operations.Compare.LtOperationSigned
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ALUTypeReader
 import SP1Chips.Lt.Constraints

--- a/SP1Chips/Mul/Constraints.lean
+++ b/SP1Chips/Mul/Constraints.lean
@@ -1,4 +1,6 @@
-import SP1Operations
+import SP1Operations.Operation.MulOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ALUTypeReader
 
 namespace Mul
 

--- a/SP1Chips/MulChip.lean
+++ b/SP1Chips/MulChip.lean
@@ -1,2 +1,4 @@
-import SP1Operations
+import SP1Operations.Operation.MulOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ALUTypeReader
 import SP1Chips.Mul.Constraints

--- a/SP1Chips/ShiftLeft/Constraints.lean
+++ b/SP1Chips/ShiftLeft/Constraints.lean
@@ -1,4 +1,6 @@
-import SP1Operations
+import SP1Operations.Operation.U16MSBOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ALUTypeReader
 
 namespace ShiftLeft
 

--- a/SP1Chips/ShiftLeftChip.lean
+++ b/SP1Chips/ShiftLeftChip.lean
@@ -1,3 +1,5 @@
 import SP1Foundations
-import SP1Operations
+import SP1Operations.Operation.U16MSBOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ALUTypeReader
 import SP1Chips.ShiftLeft.Constraints

--- a/SP1Chips/ShiftRight/Constraints.lean
+++ b/SP1Chips/ShiftRight/Constraints.lean
@@ -1,4 +1,6 @@
-import SP1Operations
+import SP1Operations.Operation.U16MSBOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ALUTypeReader
 
 namespace ShiftRight
 

--- a/SP1Chips/ShiftRightChip.lean
+++ b/SP1Chips/ShiftRightChip.lean
@@ -1,3 +1,5 @@
 import SP1Foundations
-import SP1Operations
+import SP1Operations.Operation.U16MSBOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.ALUTypeReader
 import SP1Chips.ShiftRight.Constraints

--- a/SP1Chips/Sub/Constraints.lean
+++ b/SP1Chips/Sub/Constraints.lean
@@ -1,4 +1,6 @@
-import SP1Operations
+import SP1Operations.Operation.SubOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.RTypeReader
 
 namespace Sub
 

--- a/SP1Chips/SubChip.lean
+++ b/SP1Chips/SubChip.lean
@@ -1,2 +1,4 @@
-import SP1Operations
+import SP1Operations.Operation.SubOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.RTypeReader
 import SP1Chips.Sub.Constraints

--- a/SP1Chips/Subw/Constraints.lean
+++ b/SP1Chips/Subw/Constraints.lean
@@ -1,4 +1,6 @@
-import SP1Operations
+import SP1Operations.Operation.SubwOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.RTypeReader
 
 namespace Subw
 

--- a/SP1Chips/SubwChip.lean
+++ b/SP1Chips/SubwChip.lean
@@ -1,2 +1,4 @@
-import SP1Operations
+import SP1Operations.Operation.SubwOperation
+import SP1Operations.Reader.CPUState
+import SP1Operations.Reader.RTypeReader
 import SP1Chips.Subw.Constraints


### PR DESCRIPTION
So when you edit something in `SP1Foundations` you can get the build for `SP1Chips` finished as fast as possible.